### PR TITLE
feat(options): new cookieConsentLocalStorageKey option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ export const cookieConfig: CookieConsentOptions = {
 };
 ```
 
-3. Cookie Consent checks the browser LocalStorage, if the consent is not saved it will open up automatically.
+3. Cookie Consent checks the browser [LocalStorage](#cookie-consent), if the consent is not saved it will open up automatically.
 
 4. Use `CookieConsentService` to reopen and delete the consent
 
@@ -97,4 +97,33 @@ export class AppComponent {
     this.cookies.deleteConsent();
   }
 }
+```
+
+## Cookie Consent
+
+The cookie consent is saved to the browser LocalStorage as JSON Object. Access the cookie consent in the LocalStorage by reading it with the default key `COOKIE_CONSENT`.
+
+```ts
+import { COOKIE_CONSENT_STORAGE_KEY } from @garygrossgarten/cookie-monster;
+
+readCookieConsent() {
+  // default key is COOKIE_CONSENT_STORAGE_KEY = "COOKIE_CONSENT"
+  const cookieConsentJSON = localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY);
+  const cookieConsent = JSON.parse(cookieConsentJSON);
+
+  // access cookieConsent
+}
+```
+
+`CookieConsentOptions` allows you to change the LocalStorage key for the cookie consent by using `cookieConsentLocalStorageKey`:
+
+```ts
+// cookie.config.ts
+import { CookieConsentOptions } from '@garygrossgarten/cookie-monster';
+
+export const cookieConfig: CookieConsentOptions = {
+  title: 'We use cookies 🍪',
+  cookieConsentLocalStorageKey: 'cookiemonster'
+  ...
+};
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ export const cookieConfig: CookieConsentOptions = {
 
 3. Cookie Consent checks the browser [LocalStorage](#cookie-consent), if the consent is not saved it will open up automatically.
 
-4. Use `CookieConsentService` to reopen and delete the consent
+4. Use `CookieConsentService` to show and delete the consent, access the cookie selection or pick out one cookie:
 
 ```ts
 import { Component } from '@angular/core';
@@ -95,6 +95,22 @@ export class AppComponent {
 
   deleteCookieConsent() {
     this.cookies.deleteConsent();
+  }
+
+  cookieSelection$(): Observable<CookieSelection> {
+    return this.cookies.cookieSelection$();
+  }
+
+  cookieSelectionSnapshot(): CookieSelection {
+    return this.cookies.cookieSelectionSnapshot();
+  }
+
+  acceptedCookie$(): Observable<boolean> {
+    return this.cookies.accepted$('necessary');
+  }
+
+  acceptedCookieSnapshot(): boolean {
+    return this.cookies.acceptedSnapshot('statistics');
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "build:prod": "cross-env NODE_ENV=production ng build --configuration production",
-    "build:lib": "ng build lib --configuration production && cp tailwind.config.js dist/lib",
+    "build:lib": "ng build lib --configuration production && cp tailwind.config.js dist/lib && cp README.md dist/lib",
     "publish:lib": "npm publish dist/lib",
     "deploy": "cross-env NODE_ENV=production ng deploy demo --base-href=/cookiemonster/",
     "format": "prettier --write \"src/**/*.{ts,html}\" \"projects/**/*.ts\""

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -56,7 +56,7 @@ import { CookieConsentService } from '@garygrossgarten/cookie-monster';
 
     <pre>
 
-    {{ (cookies.selection$ | async) || 'no consent yet' | json }}
+    {{ (cookies.cookieSelection$ | async) || 'no consent yet' | json }}
 
     </pre
     >

--- a/projects/lib/src/lib/banner/banner.component.ts
+++ b/projects/lib/src/lib/banner/banner.component.ts
@@ -3,9 +3,9 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
 import {
   Cookie,
-  COOKIECONSENT,
   CookieConsentOptions,
   CookieSelection,
+  cookieConsentStorageKey,
 } from '../cookie-consent.types';
 
 @Component({
@@ -147,7 +147,8 @@ export class BannerComponent implements OnInit {
   ngOnInit(): void {
     const cookies = {};
     const state: CookieSelection =
-      JSON.parse(localStorage.getItem(COOKIECONSENT.toString())) || {};
+      JSON.parse(localStorage.getItem(cookieConsentStorageKey(this.options))) ||
+      {};
     Object.keys(this.options.cookies).forEach((c) => {
       const cookie = this.options.cookies[c];
       cookies[c] = new FormControl({

--- a/projects/lib/src/lib/cookie-consent.module.ts
+++ b/projects/lib/src/lib/cookie-consent.module.ts
@@ -1,7 +1,9 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { CookieConsentOptions, COOKIECONSENT } from './cookie-consent.types';
-import { CookieConsentService } from './cookie-consent.service';
+import {
+  CookieConsentOptions,
+  COOKIE_CONSENT_OPTIONS,
+} from './cookie-consent.types';
 import { BannerModule } from './banner/banner.module';
 
 @NgModule({
@@ -9,7 +11,7 @@ import { BannerModule } from './banner/banner.module';
   imports: [CommonModule, BannerModule],
 })
 export class CookieConsentModule {
-  constructor(private cookieConsent: CookieConsentService) {}
+  constructor() {}
   static forRoot(
     options: CookieConsentOptions
   ): ModuleWithProviders<CookieConsentModule> {
@@ -17,7 +19,7 @@ export class CookieConsentModule {
       ngModule: CookieConsentModule,
       providers: [
         {
-          provide: COOKIECONSENT,
+          provide: COOKIE_CONSENT_OPTIONS,
           useValue: options,
         },
       ],

--- a/projects/lib/src/lib/cookie-consent.service.ts
+++ b/projects/lib/src/lib/cookie-consent.service.ts
@@ -16,9 +16,10 @@ import { BehaviorSubject, Subject } from 'rxjs';
 import { map, takeUntil, tap } from 'rxjs/operators';
 import { BannerComponent } from './banner/banner.component';
 import {
-  COOKIECONSENT,
+  COOKIE_CONSENT_OPTIONS,
   CookieConsentOptions,
   CookieSelection,
+  cookieConsentStorageKey,
 } from './cookie-consent.types';
 
 @Injectable({
@@ -29,7 +30,7 @@ export class CookieConsentService implements OnDestroy {
   private ref: ComponentRef<BannerComponent>;
   selection$ = new BehaviorSubject<CookieSelection>(null);
   constructor(
-    @Inject(COOKIECONSENT) private options: CookieConsentOptions,
+    @Inject(COOKIE_CONSENT_OPTIONS) private options: CookieConsentOptions,
     private componentFactoryResolver: ComponentFactoryResolver,
     private appRef: ApplicationRef,
     private injector: Injector,
@@ -38,7 +39,9 @@ export class CookieConsentService implements OnDestroy {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
-    const state = JSON.parse(localStorage.getItem(COOKIECONSENT.toString()));
+    const state = JSON.parse(
+      localStorage.getItem(cookieConsentStorageKey(this.options))
+    );
     this.selection$.next(state);
     if (!state) {
       this.showConsent();
@@ -81,8 +84,11 @@ export class CookieConsentService implements OnDestroy {
       .subscribe();
   }
 
-  private saveSelection(selection: CookieSelection | null) {
-    localStorage.setItem(COOKIECONSENT.toString(), JSON.stringify(selection));
+  private saveSelection(selection: CookieSelection | null) {
+    localStorage.setItem(
+      cookieConsentStorageKey(this.options),
+      JSON.stringify(selection)
+    );
     this.selection$.next(selection);
   }
 

--- a/projects/lib/src/lib/cookie-consent.service.ts
+++ b/projects/lib/src/lib/cookie-consent.service.ts
@@ -12,7 +12,7 @@ import {
   Injectable,
   Injector,
 } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { map, takeUntil, tap } from 'rxjs/operators';
 import { BannerComponent } from './banner/banner.component';
 import {
@@ -20,6 +20,7 @@ import {
   CookieConsentOptions,
   CookieSelection,
   cookieConsentStorageKey,
+  CookieSelectionOption,
 } from './cookie-consent.types';
 
 @Injectable({
@@ -28,7 +29,16 @@ import {
 export class CookieConsentService implements OnDestroy {
   private destroy$ = new Subject();
   private ref: ComponentRef<BannerComponent>;
-  selection$ = new BehaviorSubject<CookieSelection>(null);
+  private _cookieSelection$ = new BehaviorSubject<CookieSelection>(null);
+
+  get cookieSelection$(): Observable<CookieSelection> {
+    return this._cookieSelection$.asObservable();
+  }
+
+  get cookieSelectionSnapshot(): CookieSelection {
+    return this._cookieSelection$.getValue();
+  }
+
   constructor(
     @Inject(COOKIE_CONSENT_OPTIONS) private options: CookieConsentOptions,
     private componentFactoryResolver: ComponentFactoryResolver,
@@ -42,18 +52,19 @@ export class CookieConsentService implements OnDestroy {
     const state = JSON.parse(
       localStorage.getItem(cookieConsentStorageKey(this.options))
     );
-    this.selection$.next(state);
+    this._cookieSelection$.next(state);
     if (!state) {
       this.showConsent();
     }
   }
+
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
     if (this.ref) {
       this.ref.destroy();
     }
-    this.selection$.complete();
+    this._cookieSelection$.complete();
   }
 
   showConsent() {
@@ -89,11 +100,16 @@ export class CookieConsentService implements OnDestroy {
       cookieConsentStorageKey(this.options),
       JSON.stringify(selection)
     );
-    this.selection$.next(selection);
+    this._cookieSelection$.next(selection);
   }
 
-  accepted$(cookie: string) {
-    return this.selection$.pipe(map((s) => !!(s && s[cookie])));
+  accepted$(cookie: CookieSelectionOption): Observable<boolean> {
+    return this._cookieSelection$.pipe(map((s) => !!(s && s[cookie])));
+  }
+
+  acceptedSnapshot(cookie: CookieSelectionOption) {
+    const consent = this._cookieSelection$.getValue();
+    return !!(consent && consent[cookie]);
   }
 
   updateOptions(options: Partial<CookieConsentOptions>) {

--- a/projects/lib/src/lib/cookie-consent.types.ts
+++ b/projects/lib/src/lib/cookie-consent.types.ts
@@ -8,12 +8,13 @@ export interface CookieConsentOptions {
   showMoreLabel: string;
   showLessLabel: string;
   links: Link[];
+  cookieConsentLocalStorageKey?: string | undefined;
   cookies: {
     necessary?: Cookie;
     functional?: Cookie;
     statistics?: Cookie;
     marketing?: Cookie;
-    [key: string]: Cookie | undefined;
+    [key: string]: Cookie | undefined;
   };
 }
 
@@ -29,8 +30,10 @@ export interface Link {
   url: string;
 }
 
-export const COOKIECONSENT = new InjectionToken<CookieConsentOptions>(
-  'COOKIECONSENT'
+export const COOKIE_CONSENT_STORAGE_KEY = 'COOKIE_CONSENT';
+
+export const COOKIE_CONSENT_OPTIONS = new InjectionToken<CookieConsentOptions>(
+  'COOKIE_CONSENT_OPTIONS'
 );
 
 export interface CookieSelection {
@@ -38,5 +41,9 @@ export interface CookieSelection {
   functional?: boolean;
   statistics?: boolean;
   marketing?: boolean;
-  [key: string]: boolean | undefined;
+  [key: string]: boolean | undefined;
 }
+
+export const cookieConsentStorageKey = (
+  options: CookieConsentOptions
+): string => options.cookieConsentLocalStorageKey || COOKIE_CONSENT_STORAGE_KEY;

--- a/projects/lib/src/lib/cookie-consent.types.ts
+++ b/projects/lib/src/lib/cookie-consent.types.ts
@@ -9,13 +9,15 @@ export interface CookieConsentOptions {
   showLessLabel: string;
   links: Link[];
   cookieConsentLocalStorageKey?: string | undefined;
-  cookies: {
-    necessary?: Cookie;
-    functional?: Cookie;
-    statistics?: Cookie;
-    marketing?: Cookie;
-    [key: string]: Cookie | undefined;
-  };
+  cookies: Cookies;
+}
+
+export interface Cookies {
+  necessary?: Cookie;
+  functional?: Cookie;
+  statistics?: Cookie;
+  marketing?: Cookie;
+  [key: string]: Cookie | undefined;
 }
 
 export interface Cookie {
@@ -43,6 +45,13 @@ export interface CookieSelection {
   marketing?: boolean;
   [key: string]: boolean | undefined;
 }
+
+export type CookieSelectionOption =
+  | 'necessary'
+  | 'functional'
+  | 'statistics'
+  | 'marketing'
+  | string;
 
 export const cookieConsentStorageKey = (
   options: CookieConsentOptions


### PR DESCRIPTION
* BREAKING CHANGE: default localstorage key changed from "InjectionToken COOKIECONSENT" to "COOKIE_CONSENT"
* cookieSelection$ returns `Observable<CookieSelection>` 
* cookieSelectionSnapshot and acceptedSnapshot methods
